### PR TITLE
Don't hardcode path to runhaskell

### DIFF
--- a/bin/setup-koans
+++ b/bin/setup-koans
@@ -1,4 +1,4 @@
-#!/usr/bin/runhaskell
+#!/usr/bin/env runhaskell
 import Control.Monad (unless)
 import qualified System.Process as S
 import qualified System.Exit as S


### PR DESCRIPTION
It's better to invoke executables on hashbang lines through env(1), so they can live in various spots.
