### PR TITLE
fixes #5 (HaskVan/HaskellKoans/issues/5) readsKoan was not run

### DIFF
--- a/test/BasicFunctions.hs
+++ b/test/BasicFunctions.hs
@@ -23,7 +23,7 @@ koans = describe "BasicFunctions" $ do
 
     -- * Basic Parsing functions
     koanRead
-    --, koanReads
+    koanReads
 
     -- * Functional utilities
     koanId


### PR DESCRIPTION
Not sure why this was commented.
Was it intentional ?
Anyway 

```
reads "1566 other string"
```

will pass the test !
